### PR TITLE
STYLE: Improve the itkVectorFieldPCA class style.

### DIFF
--- a/include/itkVectorFieldPCA.h
+++ b/include/itkVectorFieldPCA.h
@@ -197,13 +197,14 @@ protected:
   virtual ~VectorFieldPCA() {};
   void PrintSelf(std::ostream& os, Indent indent) const;
 
-  void                      KernelPCA(void);
-  void                      computeMomentumSCP(void);
+  /** Kernel PCA. */
+  void KernelPCA();
+
+  /** Compute Momentum SCP. */
+  void ComputeMomentumSCP();
 
 private:
-
-  VectorFieldPCA(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(VectorFieldPCA);
 
   VectorType                m_PCAEigenValues;
 
@@ -212,7 +213,7 @@ private:
   InputPointSetPointer      m_PointSet;
   KernelFunctionPointer     m_KernelFunction;
 
-  // problem dimensions
+  // Problem dimensions
   unsigned int              m_ComponentCount;
   unsigned int              m_SetSize;
   unsigned int              m_VectorDimCount;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 itk_module_test()
 
-SET(kit PrincipalComponentsAnalysis)
-SET(${kit}Tests
+SET(PCA PrincipalComponentsAnalysis)
+SET(${PCA}Tests
   itkVectorKernelPCATest.cxx
   )
 
-SET(TEST_DATA_ROOT ${${kit}_SOURCE_DIR}/Data)
+SET(TEST_DATA_ROOT ${${PCA}_SOURCE_DIR}/Data)
 
-CreateTestDriver(${kit} "${${kit}-Test_LIBRARIES}" "${${kit}Tests}")
+CreateTestDriver(${PCA} "${${PCA}-Test_LIBRARIES}" "${${PCA}Tests}")
 
 itk_add_test(NAME itkVectorKernelPCATest
-  COMMAND ${kit}TestDriver itkVectorKernelPCATest
+  COMMAND ${PCA}TestDriver itkVectorKernelPCATest
   DATA{${TEST_DATA_ROOT}/PCATestSurface.vtk}
   DATA{${TEST_DATA_ROOT}/PCATestSurface_alpha0_01.vtk}
   DATA{${TEST_DATA_ROOT}/PCATestSurface_alpha0_02.vtk}


### PR DESCRIPTION
Use the ITK_DISALLOW_COPY_AND_ASSIGN macro to save typing the copy and
assignment method disallow statements.

Use initialization lists: initialize the missing m_VertexCount ivar to
zero; SmartPointer initialize themselves to the null pointer.

Print all member variables. Use the itkPrintSelfObjectMacro macro to
print SmartPointers.

Remove unnecessary/ducplicate/empty Doxygen-style, out-of-method-body
documentation from the implementation file/use it to improve the method
documentation in the header file.

Use the 'this' keyword when calling self functions.

Make flow control variables have a more local scope.

Start comments with capital letters.