### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkVectorFieldPCA.h
+++ b/include/itkVectorFieldPCA.h
@@ -104,6 +104,8 @@ template <
 class ITK_EXPORT VectorFieldPCA : public Object
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VectorFieldPCA);
+
   /** Standard class typedefs. */
   typedef VectorFieldPCA                  Self;
   typedef Object                          Superclass;
@@ -204,8 +206,6 @@ protected:
   void ComputeMomentumSCP();
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VectorFieldPCA);
-
   VectorType                m_PCAEigenValues;
 
   BasisSetTypePointer       m_BasisVectors;


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.