### PR TITLE
STYLE: Prefer C++11 type alias over typedef.

### DIFF
--- a/examples/VectorKernelPCA.cxx
+++ b/examples/VectorKernelPCA.cxx
@@ -43,36 +43,36 @@ int main( int argc, char *argv[] )
   int pcaCount = atoi(argv[1]);
   double kernelSigma = atof(argv[2]);
 
-  typedef double                      PointDataType;
-  typedef itk::Array<PointDataType>   PointDataVectorType;
-  typedef PointDataVectorType         PixelType;
-  typedef itk::Vector<PointDataType>  OutPointDataVectorType;
-  typedef OutPointDataVectorType      OutPixelType;
+  using PointDataType = double;
+  using PointDataVectorType = itk::Array<PointDataType>;
+  using PixelType = PointDataVectorType;
+  using OutPointDataVectorType = itk::Vector<PointDataType>;
+  using OutPixelType = OutPointDataVectorType;
 
-  typedef double             CoordRep;
+  using CoordRep = double;
   const   unsigned int       Dimension = 3;
 
-//    typedef float              PCAResultsType;
-  typedef double             PCAResultsType;
+//    using PCAResultsType = float;
+  using PCAResultsType = double;
 
   // Declare the type of the input mesh
-  typedef itk::Mesh<PixelType,Dimension>    InMeshType;
-  typedef itk::Mesh<OutPixelType,Dimension> OutMeshType;
+  using InMeshType = itk::Mesh<PixelType,Dimension>;
+  using OutMeshType = itk::Mesh<OutPixelType,Dimension>;
 
   // Declare the type of the kernel function class
-  typedef itk::GaussianDistanceKernel<CoordRep> KernelType;
+  using KernelType = itk::GaussianDistanceKernel<CoordRep>;
 
   // Declare the type of the PCA calculator
-  typedef itk::VectorFieldPCA< PointDataType, PCAResultsType,
-                                PixelType, CoordRep, KernelType, InMeshType > PCACalculatorType;
+  using PCACalculatorType = itk::VectorFieldPCA< PointDataType, PCAResultsType,
+                                PixelType, CoordRep, KernelType, InMeshType >;
 
   // Here we recover the file names from the command line arguments
   const char* inMeshFile = argv[3];
   const char* outFileNameBase = argv[4];
 
   //  We can now instantiate the types of the reader/writer.
-  typedef itk::MeshFileReader< InMeshType >   ReaderType;
-  typedef itk::MeshFileWriter< OutMeshType >  WriterType;
+  using ReaderType = itk::MeshFileReader< InMeshType >;
+  using WriterType = itk::MeshFileWriter< OutMeshType >;
 
   // create readers/writers
   ReaderType::Pointer meshReader = ReaderType::New();
@@ -220,8 +220,8 @@ int main( int argc, char *argv[] )
   InMeshType::CellsContainerConstIterator itCellsEnd = cells->End();
   outMesh->GetCells()->Reserve( cells->Size() );
 
-  typedef OutMeshType::CellType::CellAutoPointer         CellAutoPointer;
-  typedef itk::TriangleCell< OutMeshType::CellType >     TriangleType;
+  using CellAutoPointer = OutMeshType::CellType::CellAutoPointer;
+  using TriangleType = itk::TriangleCell< OutMeshType::CellType >;
 
   while ( itCells != itCellsEnd )
     {

--- a/include/itkVectorFieldPCA.h
+++ b/include/itkVectorFieldPCA.h
@@ -55,11 +55,11 @@ template< typename TRealValueType = double >
 class ITK_EXPORT GaussianDistanceKernel : public KernelFunctionBase<TRealValueType>
 {
 public:
-  /** Standard class typedefs. */
-  typedef GaussianDistanceKernel                  Self;
-  typedef KernelFunctionBase<TRealValueType>      Superclass;
-  typedef SmartPointer<Self>                      Pointer;
-  typedef SmartPointer<const Self>                ConstPointer;
+  /** Standard class type alias. */
+  using Self = GaussianDistanceKernel;
+  using Superclass = KernelFunctionBase<TRealValueType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro(GaussianDistanceKernel, KernelFunction);
@@ -106,11 +106,11 @@ class ITK_EXPORT VectorFieldPCA : public Object
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(VectorFieldPCA);
 
-  /** Standard class typedefs. */
-  typedef VectorFieldPCA                  Self;
-  typedef Object                          Superclass;
-  typedef SmartPointer<Self>              Pointer;
-  typedef SmartPointer<const Self>        ConstPointer;
+  /** Standard class type alias. */
+  using Self = VectorFieldPCA;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -119,20 +119,20 @@ public:
   itkTypeMacro(VectorFieldPCA, Object);
 
   /** Type definitions for the PointSet. */
-  typedef TPointSetType   InputPointSetType;
+  using InputPointSetType = TPointSetType;
 
   /** Definitions for points of the PointSet. */
-  typedef typename InputPointSetType::PointType     InputPointType;
+  using InputPointType = typename InputPointSetType::PointType;
 
   /** Definitions for the PointsContainer. */
-  typedef typename InputPointSetType::PointsContainer    PointsContainer;
-  typedef typename PointsContainer::Iterator             PointsContainerIterator;
+  using PointsContainer = typename InputPointSetType::PointsContainer;
+  using PointsContainerIterator = typename PointsContainer::Iterator;
 
   /** Pointer types for the PointSet. */
-  typedef typename InputPointSetType::Pointer  InputPointSetPointer;
+  using InputPointSetPointer = typename InputPointSetType::Pointer;
 
   /** Const Pointer type for the PointSet. */
-  typedef typename InputPointSetType::ConstPointer InputPointSetConstPointer;
+  using InputPointSetConstPointer = typename InputPointSetType::ConstPointer;
 
   /**
   * \brief Input PointSet dimension
@@ -141,21 +141,21 @@ public:
                       TPointSetType::PointDimension);
 
   /** type for the vector fields. */
-  typedef vnl_matrix< TVectorFieldElementType >               VectorFieldType;
-  typedef VectorContainer< unsigned int, VectorFieldType >    VectorFieldSetType;
+  using VectorFieldType = vnl_matrix< TVectorFieldElementType >;
+  using VectorFieldSetType = VectorContainer< unsigned int, VectorFieldType >;
 
-  typedef typename VectorFieldSetType::Pointer       VectorFieldSetTypePointer;
-  typedef typename VectorFieldSetType::ConstPointer  VectorFieldSetTypeConstPointer;
+  using VectorFieldSetTypePointer = typename VectorFieldSetType::Pointer;
+  using VectorFieldSetTypeConstPointer = typename VectorFieldSetType::ConstPointer;
 
   /** types for the output. */
-  typedef vnl_matrix< TPCType > MatrixType;
-  typedef vnl_vector< TPCType > VectorType;
+  using MatrixType = vnl_matrix< TPCType >;
+  using VectorType = vnl_vector< TPCType >;
 
-  typedef VectorContainer< unsigned int, MatrixType > BasisSetType;
-  typedef VectorContainer< unsigned int, VectorType > ResSetType;
+  using BasisSetType = VectorContainer< unsigned int, MatrixType >;
+  using ResSetType = VectorContainer< unsigned int, VectorType >;
 
-  typedef typename BasisSetType::Pointer         BasisSetTypePointer;
-  typedef typename KernelFunctionType::Pointer   KernelFunctionPointer;
+  using BasisSetTypePointer = typename BasisSetType::Pointer;
+  using KernelFunctionPointer = typename KernelFunctionType::Pointer;
 
   /**
   * \brief Set and get the input point set.

--- a/test/itkVectorKernelPCATest.cxx
+++ b/test/itkVectorKernelPCATest.cxx
@@ -29,7 +29,7 @@ int ParseVectorFields( std::vector< std::string > vectorFieldFilenames, typename
 {
   int testStatus = EXIT_SUCCESS;
 
-  typedef itk::MeshFileReader< TMesh > ReaderType;
+  using ReaderType = itk::MeshFileReader< TMesh >;
   typename ReaderType::Pointer meshReader = ReaderType::New();
 
   unsigned int fieldSetCount = vectorFieldFilenames.size();
@@ -116,25 +116,25 @@ int itkVectorKernelPCATest( int argc, char *argv[] )
 
   const unsigned int Dimension = 3;
 
-  typedef double                      PointDataType;
-  typedef itk::Array< PointDataType > PointDataVectorType;
-  typedef PointDataVectorType         PixelType;
-  typedef double                      CoordRep;
+  using PointDataType = double;
+  using PointDataVectorType = itk::Array< PointDataType >;
+  using PixelType = PointDataVectorType;
+  using CoordRep = double;
 
-  typedef double                      PCAResultsType;
+  using PCAResultsType = double;
 
   // Declare the type of the input mesh
-  typedef itk::Mesh< PixelType, Dimension > MeshType;
+  using MeshType = itk::Mesh< PixelType, Dimension >;
 
   // Declare the type of the kernel function class
-  typedef itk::GaussianDistanceKernel< CoordRep > KernelType;
+  using KernelType = itk::GaussianDistanceKernel< CoordRep >;
 
   // Declare the type of the PCA calculator
-  typedef itk::VectorFieldPCA< PointDataType, PCAResultsType, PixelType,
-    CoordRep, KernelType, MeshType > PCACalculatorType;
+  using PCACalculatorType = itk::VectorFieldPCA< PointDataType, PCAResultsType, PixelType,
+    CoordRep, KernelType, MeshType >;
 
   // Instantiate the reader
-  typedef itk::MeshFileReader< MeshType > ReaderType;
+  using ReaderType = itk::MeshFileReader< MeshType >;
   ReaderType::Pointer meshReader = ReaderType::New();
 
   meshReader->SetFileName( argv[1] );


### PR DESCRIPTION
Prefer C++11 type alias over typedef for the reasons stated here:
http://review.source.kitware.com/#/c/23103/