### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/examples/VectorKernelPCA.cxx
+++ b/examples/VectorKernelPCA.cxx
@@ -40,8 +40,8 @@ int main( int argc, char *argv[] )
   if(argc < MIN_ARG_COUNT)
     return (showUsage(argv[0]));
 
-  int pcaCount = atoi(argv[1]);
-  double kernelSigma = atof(argv[2]);
+  int pcaCount = std::stoi(argv[1]);
+  double kernelSigma = std::stod(argv[2]);
 
   typedef double                      PointDataType;
   typedef itk::Array<PointDataType>   PointDataVectorType;


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/