### PR TITLE
ENH: Use the ITK CMake macros to build examples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,7 @@ ELSE()
   itk_module_impl()
 ENDIF()
 
-CMAKE_DEPENDENT_OPTION(Module_${PCA}_BUILD_EXAMPLES "Build the examples" OFF "BUILD_EXAMPLES" OFF)
-if(Module_${PCA}_BUILD_EXAMPLES)
-  ADD_SUBDIRECTORY( examples )
-ENDIF()
+itk_module_examples()
 
 
 CMAKE_DEPENDENT_OPTION(Module_${PCA}_BUILD_DOCUMENTATION "Generate documentation from LaTeX files, source code examples and result screenshots" OFF


### PR DESCRIPTION
Use the ITK CMake macros to build the examples module.