### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkVectorFieldPCA.hxx
+++ b/include/itkVectorFieldPCA.hxx
@@ -19,7 +19,6 @@
 #ifndef itkVectorFieldPCA_hxx
 #define itkVectorFieldPCA_hxx
 
-#include "itkVectorFieldPCA.h"
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "vnl/vnl_c_vector.h"
 #include "itkMath.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

