### PR TITLE
ENH: Use modern ITK interface library for example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,8 +9,6 @@
 
 find_package(ITK REQUIRED COMPONENTS PrincipalComponentsAnalysis)
 
-include_directories( ${PrincipalComponentsAnalysis_SOURCE_DIR}/Source )
-
 add_executable(VectorKernelPCA VectorKernelPCA.cxx )
-target_link_libraries(VectorKernelPCA ${ITK_LIBRARIES})
+target_link_libraries(VectorKernelPCA ITK::PrincipalComponentsAnalysisModule)
 


### PR DESCRIPTION
Replace `ITK_LIBRARIES` with `ITK::PrincipalComponentsAnalysisModule` interface library.

- Remove explicit `include_directories` as the interface library handles this automatically
- Ensures proper dependency linking with modern CMake target interface libraries